### PR TITLE
Fix registry.startIdForScope is not a function for 1.24.0-beta3

### DIFF
--- a/lib/semanticolor-grammar.js
+++ b/lib/semanticolor-grammar.js
@@ -4,6 +4,7 @@ const semver = require('semver');
 const hash = require('murmurhash3js').x86.hash32;
 const packageName = 'semanticolor';
 const registry = atom.grammars;
+const textmateRegistry = atom.grammars.textmateRegistry || registry;
 const identifierChar = /((?:@|\$)?[\w\-\$]+)/;
 const symbolPrefix = /^(?:@|\$)/;
 
@@ -63,9 +64,9 @@ function semanticolorGrammarFactory(grammar, defaults, options, colorDiversity) 
 					let everythingElse = this.options.everythingElse === 'default' ? this.defaults.everythingElse : this.options.everythingElse;
 					let newScope = getNewScope(subtokens[j], actions, this.colorDiversity, includeAllChars, everythingElse);
 					if (newScope) {
-						replacement.push(registry.startIdForScope(newScope));
+						replacement.push(textmateRegistry.startIdForScope(newScope));
 						replacement.push(subtokens[j].length);
-						replacement.push(registry.endIdForScope(newScope));
+						replacement.push(textmateRegistry.endIdForScope(newScope));
 					} else {
 						replacement.push(subtokens[j].length);
 					}


### PR DESCRIPTION
This commit https://github.com/atom/atom/commit/9006d05d4f04f17b9bf96ca9a7d5fa8fdd97afdd removes the inheritance from textmateRegistry and wrap it instead. `startIdForScope` and `endIdForScope` are not proxified hence that fix.