### PR TITLE
Match unicode identifiers.

### DIFF
--- a/lib/semanticolor-grammar.js
+++ b/lib/semanticolor-grammar.js
@@ -5,7 +5,7 @@ const hash = require('murmurhash3js').x86.hash32;
 const packageName = 'semanticolor';
 const registry = atom.grammars;
 const textmateRegistry = atom.grammars.textmateRegistry || registry;
-const identifierChar = /((?:@|\$)?[a-zA-ZÀ-ÖØ-öø-ÿ\-\$]+)/;
+const identifierChar = /((?:@|\$)?[\wÀ-ÖØ-öø-ÿ\-\$]+)/;
 const symbolPrefix = /^(?:@|\$)/;
 
 let id = 'identifier.semanticolor-';

--- a/lib/semanticolor-grammar.js
+++ b/lib/semanticolor-grammar.js
@@ -5,7 +5,7 @@ const hash = require('murmurhash3js').x86.hash32;
 const packageName = 'semanticolor';
 const registry = atom.grammars;
 const textmateRegistry = atom.grammars.textmateRegistry || registry;
-const identifierChar = /((?:@|\$)?[\w\-\$]+)/;
+const identifierChar = /((?:@|\$)?[a-zA-ZÀ-ÖØ-öø-ÿ\-\$]+)/;
 const symbolPrefix = /^(?:@|\$)/;
 
 let id = 'identifier.semanticolor-';


### PR DESCRIPTION
Otherwise identifiers like `café` are not matched correctly.