### PR TITLE
Add tree-sitter support for beta and nightly versions

### DIFF
--- a/lib/semanticolor-grammar.js
+++ b/lib/semanticolor-grammar.js
@@ -14,7 +14,7 @@ let mute = 'semanticolor-mute';
 let contrast = 'semanticolor-contrast';
 let bg = 'bg';
 
-if (semver.satisfies(atom.getVersion(), '<1.13.0')) {
+if (semver.satisfies(semver.coerce(atom.getVersion()), '<1.13.0')) {
 	id = 'syntax--identifier.syntax--semanticolor-';
 	mute = 'syntax--semanticolor-mute';
 	contrast = 'syntax--semanticolor-contrast';

--- a/lib/semanticolor.js
+++ b/lib/semanticolor.js
@@ -12,6 +12,11 @@ const debug = require('debug')('semanticolor');
 const fs = require('fs');
 const path = require('path');
 
+const ATOM_SUPPORTS_TREE_SITTER = semver.satisfies(
+	semver.coerce(atom.getVersion()),
+	'>=1.52.0'
+)
+
 let lessFile = path.join(__dirname, '..', 'styles', 'semanticolor.less');
 let grammarListFile = path.join(__dirname, 'grammars.txt');
 let ignoredFileTypes = ['md', 'sh', 'cmd', 'bat', 'diff', 'Dockerfile', 'json'];
@@ -256,7 +261,7 @@ let Semanticolor = {
 		}, 30000);
 
 		atom.grammars.forEachGrammar(createGrammar);
-		if (semver.satisfies(atom.getVersion(), '>=1.52.0')) {
+		if (ATOM_SUPPORTS_TREE_SITTER) {
 			// handle not being able to register for an event when new Tree Sitter grammars are added
 			setTimeout(() => _.values(atom.grammars.treeSitterGrammarsById).forEach(createGrammar), 5000);
 			setTimeout(() => _.values(atom.grammars.treeSitterGrammarsById).forEach(createGrammar), 10000);
@@ -296,7 +301,7 @@ let Semanticolor = {
 
 		// local functions
 		function createGrammar(grammar) {
-			if (utils.isTreeSitter(grammar) && semver.satisfies(atom.getVersion(), '<1.52.0')) {
+			if (utils.isTreeSitter(grammar) && !ATOM_SUPPORTS_TREE_SITTER) {
 				return;
 			}
 
@@ -363,7 +368,7 @@ let Semanticolor = {
 				return result;
 			}
 			if (grammar.name && !grammar.scopeName.includes('null-grammar')
-				&& (!utils.isTreeSitter(grammar) || semver.satisfies(atom.getVersion(), '>=1.52.0'))
+				&& (!utils.isTreeSitter(grammar) || ATOM_SUPPORTS_TREE_SITTER)
 				&& ((grammar.scopeName.includes('source') && grammar.fileTypes && grammar.fileTypes.length
 				&& Sugar.Array.intersect(grammar.fileTypes, ignoredFileTypes).length === 0)
 				|| (grammar.fileTypes && Sugar.Array.intersect(grammar.fileTypes, forceIncludeFileTypes).length > 0))) {


### PR DESCRIPTION
This PR fixes semanticolor's tree-sitter support in beta and nightly builds, which is currently broken because of how the Atom's version is being checked by `semver`.

The problematic code snippet is `semver.satisfies(atom.getVersion(), '>=1.52.0')`. This works fine for regular builds, where the version string is a bare semver string like `1.59.0`, but beta and nightly builds return a version string ending in `...-beta0` and `...-nightly0`, resp, and semver doesn't understand them.
This results in beta and nightly users of sematicolor not having access to the tree-sitter support and always being forced to use the TM grammars.

My solution is to just use `semver.coerce(atom.getVersion())` to chop off the trailing build type. Docs for `coerce` are at https://github.com/npm/node-semver#coercion

I've poked around at this locally and it's working just fine: semanticolor is working w/ tree-sitter grammars as expected.

Thanks!